### PR TITLE
Escape pingback label output

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -668,7 +668,7 @@ if ( ! function_exists( 'fukasawa_comment' ) ) {
 		
 		<li <?php comment_class(); ?> id="comment-<?php comment_ID(); ?>">
 		
-			<?php __( 'Pingback:', 'fukasawa' ); ?> <?php comment_author_link(); ?> <?php edit_comment_link( __( 'Edit', 'fukasawa' ), '<span class="edit-link">', '</span>' ); ?>
+			<?php esc_html_e( 'Pingback:', 'fukasawa' ); ?> <?php comment_author_link(); ?> <?php edit_comment_link( __( 'Edit', 'fukasawa' ), '<span class="edit-link">', '</span>' ); ?>
 			
 		</li>
 		<?php


### PR DESCRIPTION
## Summary
- escape the pingback/trackback label output in the custom comment callback so it renders as visible text

## Testing
- not run (WordPress environment not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd7068c5748331a761b0202e921fb4