### PR TITLE
Guard sticky post exclusions in recent posts widget

### DIFF
--- a/widgets/recent-posts.php
+++ b/widgets/recent-posts.php
@@ -30,10 +30,18 @@ class fukasawa_recent_posts extends WP_Widget {
 				
 				<?php
 
-				global $post;
-				$sticky = get_option( 'sticky_posts' );	
+                                global $post;
+                                $sticky = get_option( 'sticky_posts' );
+                                $sticky = is_array( $sticky ) ? array_values( array_filter( array_map( 'absint', $sticky ) ) ) : array();
 
-				$not_in = array( $sticky[0], $post->ID );
+                                $not_in = array();
+                                if ( isset( $sticky[0] ) ) {
+                                        $not_in[] = $sticky[0];
+                                }
+                                if ( isset( $post->ID ) ) {
+                                        $not_in[] = (int) $post->ID;
+                                }
+                                $not_in = array_values( array_unique( array_filter( $not_in ) ) );
 				
 				if ( $number_of_posts == 0 ) $number_of_posts = 5;
 				


### PR DESCRIPTION
## Summary
- guard the sticky post array before accessing the first element in the recent posts widget
- filter the sticky post IDs and only include valid values in the exclusion list

## Testing
- php -l widgets/recent-posts.php

------
https://chatgpt.com/codex/tasks/task_e_68cd723a8df083319e59fdc0e3c7ece3