### PR TITLE
Fetch linked post images for lightbox overlay

### DIFF
--- a/content.php
+++ b/content.php
@@ -53,7 +53,7 @@
 
                                 <figure class="featured-media">
 
-                                        <a class="post-lightbox-trigger" href="<?php echo esc_url( $full_image ? $full_image : get_permalink() ); ?>" data-lightbox-srcset="<?php echo esc_attr( $srcset ); ?>" data-lightbox-sizes="<?php echo esc_attr( $sizes ); ?>" data-lightbox-alt="<?php echo esc_attr( $alt_text ? $alt_text : get_the_title() ); ?>" data-lightbox-caption="<?php echo esc_attr( get_the_title() ); ?>">
+                                        <a class="post-lightbox-trigger" href="<?php echo esc_url( $full_image ? $full_image : get_permalink() ); ?>" data-lightbox-permalink="<?php echo esc_url( get_permalink() ); ?>" data-lightbox-srcset="<?php echo esc_attr( $srcset ); ?>" data-lightbox-sizes="<?php echo esc_attr( $sizes ); ?>" data-lightbox-alt="<?php echo esc_attr( $alt_text ? $alt_text : get_the_title() ); ?>" data-lightbox-caption="<?php echo esc_attr( get_the_title() ); ?>">
 
                                                 <?php echo wp_get_attachment_image( $thumbnail_id, 'post-thumb', false, array( 'loading' => 'lazy', 'class' => 'post-thumbnail-image' ) ); ?>
 
@@ -80,7 +80,7 @@
                                 ?>
 
                                 <figure class="featured-media">
-                                        <a class="post-lightbox-trigger" href="<?php echo esc_url( $full_image ? $full_image : get_permalink() ); ?>" data-lightbox-srcset="<?php echo esc_attr( $srcset ); ?>" data-lightbox-sizes="<?php echo esc_attr( $sizes ); ?>" data-lightbox-alt="<?php echo esc_attr( $alt_text ? $alt_text : get_the_title() ); ?>" data-lightbox-caption="<?php echo esc_attr( get_the_title() ); ?>">
+                                        <a class="post-lightbox-trigger" href="<?php echo esc_url( $full_image ? $full_image : get_permalink() ); ?>" data-lightbox-permalink="<?php echo esc_url( get_permalink() ); ?>" data-lightbox-srcset="<?php echo esc_attr( $srcset ); ?>" data-lightbox-sizes="<?php echo esc_attr( $sizes ); ?>" data-lightbox-alt="<?php echo esc_attr( $alt_text ? $alt_text : get_the_title() ); ?>" data-lightbox-caption="<?php echo esc_attr( get_the_title() ); ?>">
                                                 <?php echo wp_get_attachment_image( $thumbnail_id, 'post-thumb', false, array( 'loading' => 'lazy', 'class' => 'post-thumbnail-image' ) ); ?>
                                                 <span class="screen-reader-text"><?php printf( __( 'Open full-size image of %s', 'fukasawa' ), get_the_title() ); ?></span>
                                         </a>


### PR DESCRIPTION
### Motivation
- Allow archive/smart thumbnails to open a lightbox populated with images from the linked single post rather than only the archive image.
- Ensure the lightbox can fetch and parse the linked post HTML to extract featured/content images when available.
- Match the clicked thumbnail to the correct image in the fetched list using normalized sources and filename fallbacks.
- Preserve existing lightbox keyboard navigation and fallback behavior when fetching fails or is not applicable.

### Description
- Add `data-lightbox-permalink` to archive featured-media anchors in `content.php` so the script can fetch the linked post URL via `get_permalink()`.
- Introduce `fetchRequestId`, `getNormalizedSource`, `getSourceBasename`, `getImageSource`, and `getTriggerData` helpers in `assets/js/lightbox.js` to normalize and read trigger/image data.
- Add `getPostImages` to fetch and parse a post HTML, extract `.featured-media img` and `.post-content img` elements into a de-duped image list, and `findMatchingIndex` to locate the clicked image in that list.
- Refactor `preloadAdjacent` and `setImage` to use trigger data objects, and update the document `click` handler to attempt fetching the linked post images (falling back to existing on-page triggers when unavailable).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964ecdcb5f88331b9c0ed32cca0e6e9)